### PR TITLE
feat: 회원(고객) 이메일 인증 구현

### DIFF
--- a/user-api/build.gradle
+++ b/user-api/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 
     //mailgun
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    //email 인증 랜덤 코드 생성
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
 
     //BaseEntity 사용
     implementation 'org.springframework.data:spring-data-envers'

--- a/user-api/src/main/java/org/silluck/user/application/SignUpApplication.java
+++ b/user-api/src/main/java/org/silluck/user/application/SignUpApplication.java
@@ -1,0 +1,72 @@
+package org.silluck.user.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.silluck.user.client.MailgunClient;
+import org.silluck.user.client.mailgun.SendMailForm;
+import org.silluck.user.domain.dto.request.SignUpForm;
+import org.silluck.user.domain.entity.Customer;
+import org.silluck.user.exception.CustomException;
+import org.silluck.user.service.SignUpCustomerService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.silluck.user.exception.ErrorCode.ALREADY_EXIST_USER;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SignUpApplication {    // 회원계정과 인증메일을 보내는 역할 확실히 하기 위해 service에서 분리
+
+    private final MailgunClient mailgunClient;
+    private final SignUpCustomerService signUpCustomerService;
+
+    public void verifyCustomer(String email, String code) {
+        signUpCustomerService.verifyEmail(email, code);
+    }
+
+    @Transactional
+    public String customerSignUp(SignUpForm form) {
+        if (signUpCustomerService.isEmailExist(form.getEmail())) {
+            // custom exception
+            throw new CustomException(ALREADY_EXIST_USER);
+        } else {
+            Customer customer = signUpCustomerService.signUp(form);
+
+            String code = getRandomCode();
+            SendMailForm sendMailForm = SendMailForm.builder()
+                    .from("silluckofficial@silluck.com")
+                    .to(form.getEmail())
+                    .subject("Verification Email")
+                    .text(getVerificationEmailBody(
+                            form.getEmail(), form.getNickname(), code))
+                    .build();
+
+            log.info("Send Email Result : {}", mailgunClient.sendEmail(sendMailForm));
+
+            signUpCustomerService.changeCustomerValidationEmail(customer.getId(), code);
+
+            return "회원 가입에 성공하셨습니다.";
+        }
+    }
+
+    //이메일 발송 준비
+    // 인증 코드 생성
+    private String getRandomCode() {
+        // 코드를 줄이고 생산성 높이기 위해 외부 라이브러리 사용
+        return RandomStringUtils.random(10, true, true);    // 숫자와 문자 모두 사용해서 10자리 코드 생성
+    }
+
+    //이메일을 위한 템플릿
+    private String getVerificationEmailBody(String email, String name, String code) {
+        StringBuilder stringBuilder = new StringBuilder();
+        return stringBuilder.append("Hello ").append(name)
+                .append("! Please Click Link for verification.\n\n")
+                .append("http://localhost:8081/customer/sighup/verify?email=")
+                .append(email)
+                .append("&code=")
+                .append(code).toString();
+    }
+
+}

--- a/user-api/src/main/java/org/silluck/user/controller/SignUpController.java
+++ b/user-api/src/main/java/org/silluck/user/controller/SignUpController.java
@@ -1,0 +1,26 @@
+package org.silluck.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.silluck.user.application.SignUpApplication;
+import org.silluck.user.domain.dto.request.SignUpForm;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/customer/signup")
+public class SignUpController {
+
+    private final SignUpApplication signUpApplication;
+
+    @PostMapping
+    public ResponseEntity<String> customerSignup(@RequestBody SignUpForm form) {
+        return ResponseEntity.ok(signUpApplication.customerSignUp(form));
+    }
+
+    @PutMapping("/verify")
+    public ResponseEntity<String> verifyCustomer(String email, String code) {   // 이메일을 노출시키는 상황 암호화 고려
+        signUpApplication.verifyCustomer(email, code);
+        return ResponseEntity.ok("인증이 완료되었습니다.");
+    }
+}

--- a/user-api/src/main/java/org/silluck/user/domain/dto/request/SignUpForm.java
+++ b/user-api/src/main/java/org/silluck/user/domain/dto/request/SignUpForm.java
@@ -1,4 +1,4 @@
-package org.silluck.user.domain;
+package org.silluck.user.domain.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/user-api/src/main/java/org/silluck/user/domain/entity/Customer.java
+++ b/user-api/src/main/java/org/silluck/user/domain/entity/Customer.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.envers.AuditOverride;
-import org.silluck.user.domain.SignUpForm;
+import org.silluck.user.domain.dto.request.SignUpForm;
 
 import java.time.LocalDateTime;
 import java.util.Locale;
@@ -46,4 +46,15 @@ public class Customer extends BaseEntity {
                 .build();
     }
 
+    public void setVerifyExpiredAt(LocalDateTime verifyExpiredAt) {
+        this.verifyExpiredAt = verifyExpiredAt;
+    }
+
+    public void setVerifiedCode(String verifiedCode) {
+        this.verifiedCode = verifiedCode;
+    }
+
+    public void setVerify(boolean verify) {
+        this.verify = verify;
+    }
 }

--- a/user-api/src/main/java/org/silluck/user/exception/CustomException.java
+++ b/user-api/src/main/java/org/silluck/user/exception/CustomException.java
@@ -1,0 +1,14 @@
+package org.silluck.user.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    // 커스텀으로 예외처리하여 상태관리에 적합하게
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getDetail());
+        this.errorCode = errorCode;
+    }
+}

--- a/user-api/src/main/java/org/silluck/user/exception/ErrorCode.java
+++ b/user-api/src/main/java/org/silluck/user/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package org.silluck.user.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+
+    // 유저 - customer
+    ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
+    NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 유저가 없습니다."),
+    ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료 되었습니다."),
+    EXPIRED_CODE(HttpStatus.BAD_REQUEST, "인증시가닝 만료되었습니다."),
+    WRONG_VERIFICATION(HttpStatus.BAD_REQUEST, "잘못된 인증 시도입니다.");
+    //
+
+    private final HttpStatus httpStatus;
+    private final String detail;
+
+}

--- a/user-api/src/main/java/org/silluck/user/exception/ExceptionController.java
+++ b/user-api/src/main/java/org/silluck/user/exception/ExceptionController.java
@@ -1,0 +1,32 @@
+package org.silluck.user.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class ExceptionController {
+
+    @ExceptionHandler({CustomException.class})
+    public ResponseEntity<ExceptionResponse> customRequestException(
+            final CustomException customException) {
+
+        log.warn("api Exception : {}", customException.getErrorCode());
+
+        return ResponseEntity.badRequest().body(new ExceptionResponse
+                (customException.getMessage(), customException.getErrorCode()));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @ToString   // 정상적이 호출위해
+    public static class ExceptionResponse {
+        private String message;
+        private ErrorCode errorCode;
+    }
+}

--- a/user-api/src/main/java/org/silluck/user/repository/CustomerRepository.java
+++ b/user-api/src/main/java/org/silluck/user/repository/CustomerRepository.java
@@ -1,9 +1,12 @@
-package org.silluck.user.domain.repository;
+package org.silluck.user.repository;
 
 import org.silluck.user.domain.entity.Customer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CustomerRepository extends JpaRepository<Customer, Long> {
+    Optional<Customer> findByEmail(String email);
 }

--- a/user-api/src/main/java/org/silluck/user/service/SignUpCustomerService.java
+++ b/user-api/src/main/java/org/silluck/user/service/SignUpCustomerService.java
@@ -1,10 +1,17 @@
 package org.silluck.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.silluck.user.domain.SignUpForm;
+import org.silluck.user.domain.dto.request.SignUpForm;
 import org.silluck.user.domain.entity.Customer;
-import org.silluck.user.domain.repository.CustomerRepository;
+import org.silluck.user.exception.CustomException;
+import org.silluck.user.repository.CustomerRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.silluck.user.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +21,44 @@ public class SignUpCustomerService {
 
     public Customer signUp(SignUpForm form) {
         return customerRepository.save(Customer.from(form));
+    }
+
+    public boolean isEmailExist(String email) {
+        return customerRepository.findByEmail(email).isPresent();
+    }
+
+    @Transactional
+    public void verifyEmail(String email, String code) {
+        Customer customer = customerRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
+
+        // 이미 인증을 완료한 경우
+        if (customer.isVerify()) {
+            throw new CustomException(ALREADY_VERIFIED);
+        }
+        // 인증코드가 다를 경우
+        else if (!customer.getVerifiedCode().equals(code)) {
+            throw new CustomException(WRONG_VERIFICATION);
+        }
+        // 설정한 인증 시간이 지난 경우
+        else if (customer.getVerifyExpiredAt().isBefore(LocalDateTime.now())) {
+            throw new CustomException(EXPIRED_CODE);
+        }
+
+        customer.setVerify(true);
+    }
+
+    @Transactional
+    public LocalDateTime changeCustomerValidationEmail(Long customerId, String verificationCode) {
+        Optional<Customer> customerOptional = customerRepository.findById(customerId);
+
+        if (customerOptional.isPresent()) {
+            Customer customer = customerOptional.get();
+            customer.setVerifiedCode(verificationCode);
+            customer.setVerifyExpiredAt(LocalDateTime.now().plusDays(1));
+            return customer.getVerifyExpiredAt();
+        }
+
+        throw new CustomException(NOT_FOUND_USER);
     }
 }

--- a/user-api/src/main/resources/application.yml
+++ b/user-api/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
   #      hibernate.format_sql: true
 
   datasource:
-    url: jdbc:mysql://localhost:3306/user?useSSL=false,useUnicode=true&allowPublicKeyRetrieval=true
+    url: jdbc:mysql://localhost:3306/user?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: root
     password: ${DB_PASSWORD}

--- a/user-api/src/test/java/org/silluck/user/service/SignUpCustomerServiceTest.java
+++ b/user-api/src/test/java/org/silluck/user/service/SignUpCustomerServiceTest.java
@@ -1,7 +1,7 @@
 package org.silluck.user.service;
 
 import org.junit.jupiter.api.Test;
-import org.silluck.user.domain.SignUpForm;
+import org.silluck.user.domain.dto.request.SignUpForm;
 import org.silluck.user.domain.entity.Customer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
close #

이번 PR에서는 회원가입 시 이메일 인증 기능을 추가하였습니다. 사용자가 회원가입을 진행하면, 인증 이메일이 발송되고 이를 통해 계정을 활성화할 수 있습니다. 주요 변경 사항은 아래와 같습니다.

## 🛰️ Issue Number
#8 (메일인증)

## 작업종류
- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용


## 📚 Reference
1. 이메일 인증 기능 구현
- SignUpApplication 서비스: 회원가입 및 이메일 인증 로직을 담당하는 서비스입니다.
    - customerSignUp: 사용자가 회원가입 시, 메일을 발송하고 인증 코드를 생성합니다.
    - verifyCustomer: 사용자가 받은 인증 코드로 이메일 인증을 완료할 수 있도록 합니다. 발송된 링크 클릭 시 로그인이 가능합니다.
    - 인증 코드 유효기간은 1일입니다.
- MailgunClient 사용: 이메일 발송을 위해 Mailgun API를 사용하였으며, 이전에 만든 클라이언트 및 SendMailForm을 통해 메일 내용을 구성합니다.
- 랜덤 코드 생성: Apache Commons의 RandomStringUtils를 이용하여 인증에 필요한 랜덤 코드를 생성합니다.

2. 회원가입 컨트롤러 구현
- SignUpController 클래스: 회원가입 및 이메일 인증을 위한 API 엔드포인트를 제공하는 컨트롤러입니다.
    - customerSignup: POST 요청으로 회원가입을 처리하며, 이메일 인증 메일을 발송합니다.
    - verifyCustomer: 사용자가 PUT 요청을 통해 이메일 인증을 처리할 수 있도록 합니다.

3. 예외 처리 및 커스텀 예외 구현
- CustomException 클래스: 다양한 회원가입 및 인증 시 발생할 수 있는 예외를 처리하는 커스텀 예외 클래스입니다.
- ErrorCode Enum: 예외 상황을 정의한 코드들을 관리합니다. 예를 들어, 이미 존재하는 회원, 잘못된 인증 코드, 인증 시간 만료 등의 예외가 있습니다.
- ExceptionController 클래스: 전역 예외 처리를 통해 API 호출 시 발생하는 예외를 메시지와 에러코드로 표현합니다.

4. 회원 인증 로직 추가
- SignUpCustomerService 클래스: 회원가입과 인증 관련 로직을 수행하는 서비스입니다.
- verifyEmail: 이메일 인증을 처리하며, 잘못된 인증 코드, 인증 만료, 이미 인증된 계정에 대한 처리를 합니다.
- changeCustomerValidationEmail: 인증 메일 발송 후, 인증 코드를 저장하고 만료 시간을 설정합니다.
- isEmailExist: 이메일 중복 체크 기능이 추가되었습니다.

5. 기타 사항
- Apache Commons 라이브러리를 활용하여 랜덤 인증 코드를 생성하였으며, 이 코드를 메일로 발송하여 사용자 계정의 유효성을 검증합니다.
- 현재 로컬에서 테스트 시, 메일 발송 기능이 동작하지 않도록 설정되어 있으므로 실제 메일 발송은 서버 환경에서 확인이 필요합니다.

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
