### PR TITLE
feat: 회원(고객) 예치금 관리

### DIFF
--- a/user-api/src/main/java/org/silluck/user/controller/CustomerController.java
+++ b/user-api/src/main/java/org/silluck/user/controller/CustomerController.java
@@ -4,15 +4,14 @@ import lombok.RequiredArgsConstructor;
 import org.silluck.domain.config.JwtAuthenticationProvider;
 import org.silluck.domain.domain.common.UserVo;
 import org.silluck.user.domain.customer.CustomerDTO;
+import org.silluck.user.domain.dto.request.ChangeBalanceForm;
 import org.silluck.user.domain.entity.Customer;
 import org.silluck.user.exception.CustomException;
 import org.silluck.user.exception.ErrorCode;
+import org.silluck.user.service.customer.CustomerBalanceService;
 import org.silluck.user.service.customer.CustomerService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/customer")
@@ -21,6 +20,7 @@ public class CustomerController {
 
     private final JwtAuthenticationProvider provider;
     private final CustomerService customerService;
+    private final CustomerBalanceService customerBalanceService;
 
     @GetMapping("/getInfo")
     public ResponseEntity<CustomerDTO> getInfo(
@@ -32,5 +32,14 @@ public class CustomerController {
                         () -> new CustomException(ErrorCode.NOT_FOUND_USER));
 
         return ResponseEntity.ok(CustomerDTO.from(customer));
+    }
+
+    @PostMapping("/balance")
+    public ResponseEntity<Integer> changeBalance(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestBody ChangeBalanceForm form) {
+        UserVo userVo = provider.getUserVo(token);
+        return ResponseEntity.ok(customerBalanceService
+                .changeBalance(userVo.getId(), form).getCurrentMoney());
     }
 }

--- a/user-api/src/main/java/org/silluck/user/domain/customer/CustomerDTO.java
+++ b/user-api/src/main/java/org/silluck/user/domain/customer/CustomerDTO.java
@@ -12,8 +12,13 @@ public class CustomerDTO {
 
     private Long id;
     private String email;
+    private Integer balance;
 
     public static CustomerDTO from(Customer customer) {
-        return new CustomerDTO(customer.getId(), customer.getEmail());
+        return CustomerDTO.builder()
+                .id(customer.getId())
+                .email(customer.getEmail())
+                .balance(customer.getBalance() == null ? 0 : customer.getBalance())
+                .build();
     }
 }

--- a/user-api/src/main/java/org/silluck/user/domain/dto/request/ChangeBalanceForm.java
+++ b/user-api/src/main/java/org/silluck/user/domain/dto/request/ChangeBalanceForm.java
@@ -1,0 +1,16 @@
+package org.silluck.user.domain.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChangeBalanceForm {    // 출금과 입금을 위한 폼
+    private String from;
+    private String message;
+    private Integer money;
+}

--- a/user-api/src/main/java/org/silluck/user/domain/entity/Customer.java
+++ b/user-api/src/main/java/org/silluck/user/domain/entity/Customer.java
@@ -36,6 +36,9 @@ public class Customer extends BaseEntity {
     private String verifiedCode;
     private boolean verify;
 
+    @Column(columnDefinition = "int default 0")
+    private Integer balance;    //  현재 잔액 이중화하여 저장
+
     public static Customer from(SignUpForm form) {
         return Customer.builder()
                 .email(form.getEmail().toLowerCase(Locale.ROOT))
@@ -57,5 +60,9 @@ public class Customer extends BaseEntity {
 
     public void setVerify(boolean verify) {
         this.verify = verify;
+    }
+
+    public void setBalance(Integer balance) {
+        this.balance = balance;
     }
 }

--- a/user-api/src/main/java/org/silluck/user/domain/entity/CustomerBalanceHistory.java
+++ b/user-api/src/main/java/org/silluck/user/domain/entity/CustomerBalanceHistory.java
@@ -1,0 +1,31 @@
+package org.silluck.user.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.envers.AuditOverride;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@AuditOverride(forClass = BaseEntity.class)
+@Entity
+public class CustomerBalanceHistory extends BaseEntity {
+    @Id
+    @Column(name = "Id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(targetEntity = Customer.class, fetch = FetchType.LAZY)
+    private Customer customer;
+    // 변경된 돈
+    private Integer changeMoney;
+    // 해당 시점 잔액
+    private Integer currentMoney;
+    // 누구로 부터 이벤트 발생
+    private String fromMessage;
+    private String description;
+}

--- a/user-api/src/main/java/org/silluck/user/exception/ErrorCode.java
+++ b/user-api/src/main/java/org/silluck/user/exception/ErrorCode.java
@@ -7,16 +7,18 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 @Getter
 public enum ErrorCode {
-
-    // 유저 - customer, 회원가입
+    // 유저
+    //회원가입
     ALREADY_EXIST_USER(HttpStatus.BAD_REQUEST, "이미 가입된 회원입니다."),
     NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "일치하는 유저가 없습니다."),
     ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료 되었습니다."),
     EXPIRED_CODE(HttpStatus.BAD_REQUEST, "인증시가닝 만료되었습니다."),
     WRONG_VERIFICATION(HttpStatus.BAD_REQUEST, "잘못된 인증 시도입니다."),
-
-    // 유저 - customer, 로그인
-    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "로그인 실패, 이메일이나 비밀번호를 확인해주세요.");
+    // 로그인
+    LOGIN_CHECK_FAIL(HttpStatus.BAD_REQUEST, "로그인 실패, 이메일이나 비밀번호를 확인해주세요."),
+    // 예치금 관리
+    NOT_ENOUGH_BALANCE(HttpStatus.BAD_REQUEST, "잔액이 부족합니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/user-api/src/main/java/org/silluck/user/repository/CustomerBalanceHistoryRepository.java
+++ b/user-api/src/main/java/org/silluck/user/repository/CustomerBalanceHistoryRepository.java
@@ -1,0 +1,14 @@
+package org.silluck.user.repository;
+
+import org.silluck.user.domain.entity.CustomerBalanceHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.Optional;
+
+@Repository
+public interface CustomerBalanceHistoryRepository extends JpaRepository<CustomerBalanceHistory, Long> {
+    Optional<CustomerBalanceHistory> findFirstByCustomer_IdOrderByIdDesc(    // 가장 최신의 데이터 가저옴
+            @RequestParam("customer_id") Long customerId);
+}

--- a/user-api/src/main/java/org/silluck/user/repository/SellerRepository.java
+++ b/user-api/src/main/java/org/silluck/user/repository/SellerRepository.java
@@ -2,9 +2,11 @@ package org.silluck.user.repository;
 
 import org.silluck.user.domain.entity.Seller;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+@Repository
 public interface SellerRepository extends JpaRepository<Seller, Long> {
     Optional<Seller> findByEmail(String email);
 }

--- a/user-api/src/main/java/org/silluck/user/service/customer/CustomerBalanceService.java
+++ b/user-api/src/main/java/org/silluck/user/service/customer/CustomerBalanceService.java
@@ -1,0 +1,50 @@
+package org.silluck.user.service.customer;
+
+import lombok.RequiredArgsConstructor;
+import org.silluck.user.domain.dto.request.ChangeBalanceForm;
+import org.silluck.user.domain.entity.CustomerBalanceHistory;
+import org.silluck.user.exception.CustomException;
+import org.silluck.user.repository.CustomerBalanceHistoryRepository;
+import org.silluck.user.repository.CustomerRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.silluck.user.exception.ErrorCode.NOT_ENOUGH_BALANCE;
+import static org.silluck.user.exception.ErrorCode.NOT_FOUND_USER;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerBalanceService {
+
+    private final CustomerBalanceHistoryRepository customerBalanceHistoryRepository;
+    private final CustomerRepository customerRepository;
+
+    @Transactional(noRollbackFor = {CustomException.class}) // 해당 exception이 나와 있을 때 noRollback
+    public CustomerBalanceHistory changeBalance(Long customerId, ChangeBalanceForm form) throws CustomException {   // 잔액 부족 같은 예외
+
+        CustomerBalanceHistory customerBalanceHistory =
+                customerBalanceHistoryRepository.findFirstByCustomer_IdOrderByIdDesc(customerId)
+                        .orElse(CustomerBalanceHistory.builder()
+                                .changeMoney(0)
+                                .currentMoney(0)
+                                .customer(customerRepository.findById(customerId)
+                                        .orElseThrow(() -> new CustomException(NOT_FOUND_USER)))
+                                .build());
+
+        if (customerBalanceHistory.getCurrentMoney() + form.getMoney() < 0) {
+            throw new CustomException(NOT_ENOUGH_BALANCE);
+        }
+
+        customerBalanceHistory = CustomerBalanceHistory.builder()
+                .changeMoney(form.getMoney())
+                .currentMoney(customerBalanceHistory.getCurrentMoney() + form.getMoney())
+                .description(form.getMessage())
+                .fromMessage(form.getFrom())
+                .customer(customerBalanceHistory.getCustomer())
+                .build();
+
+        customerBalanceHistory.getCustomer().setBalance(customerBalanceHistory.getCurrentMoney());
+
+        return customerBalanceHistoryRepository.save(customerBalanceHistory);
+    }
+}


### PR DESCRIPTION
close #

- 이번 PR에서는 고객 예치금 관리 기능을 구현하였습니다.
- 고객의 예치금 변동 이력 기록 및 잔액 관리 기능을 추가하였습니다.

## 🛰️ Issue Number
#17 

## 작업종류
- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용
1. 고객 예치금 관리:
- CustomerBalanceService 클래스에서 고객의 예치금을 관리하는 changeBalance 메서드를 추가.
- 고객 예치금의 증가 또는 감소에 따른 변동 이력을 CustomerBalanceHistory 엔티티에 기록하도록 구현.
- 예치금 잔액이 부족할 경우 예외를 발생시키는 로직을 추가.

2. 컨트롤러 추가:
- CustomerController에 /balance 엔드포인트를 추가하여 고객의 예치금을 변경할 수 있는 API를 구현.
- JWT 토큰을 활용하여 인증된 고객만이 자신의 예치금을 관리.

3. 엔티티 및 DTO 수정:
- CustomerDTO에 balance 필드를 추가하여 고객의 잔액 정보를 포함하도록 변경.
- Customer 엔티티에 balance 필드 추가, 데이터 이중화하여 관리.

4. 엔티티 및 레포지토리 추가:
- CustomerBalanceHistory 엔티티를 추가하여 고객의 예치금 변동 이력을 관리.
- CustomerBalanceHistoryRepository 인터페이스를 통해 고객의 예치금 변동 이력을 DB에서 조회하고 저장할 수 있는 메서드를 추가.

## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
