### PR TITLE
fix: JwtAuthenticationFilter seller 타입 반영

### DIFF
--- a/user-api/src/main/java/org/silluck/user/config/SecurityConfig.java
+++ b/user-api/src/main/java/org/silluck/user/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> {
                     try {
                         authorize
-                                .requestMatchers("/signup/**","signin/**",
+                                .requestMatchers("/signup/**", "signin/**",
                                         //swagger 허용 URL
                                         "/v2/api-docs", "/v3/api-docs", "/v3/api-docs/**", "/swagger-resources",
                                         "/swagger-resources/**", "/configuration/ui", "/configuration/security", "/swagger-ui/**",

--- a/user-api/src/main/java/org/silluck/user/config/filter/JwtAuthenticationFilter.java
+++ b/user-api/src/main/java/org/silluck/user/config/filter/JwtAuthenticationFilter.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.silluck.domain.config.JwtAuthenticationProvider;
 import org.silluck.domain.domain.common.UserVo;
 import org.silluck.user.service.customer.CustomerService;
+import org.silluck.user.service.seller.SellerService;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -28,6 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtAuthenticationProvider tokenProvider;
     private final CustomerService customerService;
+    private final SellerService sellerService;
 
     // 실제 필터링 로직은 doFilterInternal 에 들어감
     // JWT 토큰의 인증 정보를 현재 쓰레드의 SecurityContext 에 저장하는 역할 수행
@@ -60,8 +62,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
             // 고객 정보가 있는지 확인
-            customerService.findByIdAndEmail(userVo.getId(), userVo.getEmail()).orElseThrow(
-                    () -> new ServletException("Invalid Access"));  // 토큰이 유효한지 확인 위해 DB 조회
+            if (role.equals("CUSTOMER")) {
+                customerService.findByIdAndEmail(userVo.getId(), userVo.getEmail()).orElseThrow(
+                        () -> new ServletException("Invalid Access"));  // 토큰이 유효한지 확인 위해 DB 조회
+            } else if (role.equals("SELLER")) {
+                sellerService.findByIdAndEmail(userVo.getId(), userVo.getEmail()).orElseThrow(
+                        () -> new ServletException("Invalid Access"));  // 토큰이 유효한지 확인 위해 DB 조회
+            }
         } else {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             response.setCharacterEncoding("UTF-8");


### PR DESCRIPTION
close #

이번 커밋에서는 JWT 필터에 SELLER 인증 로직을 추가하였습니다.
기존 고객(CUSTOMER) 인증과 함께 판매자(SELLER)에 대한 인증 처리도 가능하도록 확장하였습니다.

## 🛰️ Issue Number
#19 

## 작업종류
- [ ] test 코드 작성
- [ ] feature 병합
- [x] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용
1. SELLER 인증 로직 추가:
- JwtAuthenticationFilter 클래스에서 JWT 토큰의 역할(Role)을 기반으로, 고객(CUSTOMER)과 판매자(SELLER)에 대해 각각의 인증 로직을 처리하도록 수정하였습니다.
- SELLER 역할의 토큰이 주어졌을 경우, SellerService를 통해 판매자의 ID와 이메일을 검증하도록 하였습니다.

2. 서비스 추가:
- SellerService를 JwtAuthenticationFilter에 주입하여 판매자에 대한 검증이 가능하도록 설정하였습니다.

3. 예외 처리:
- 고객 또는 판매자의 정보가 유효하지 않을 경우, ServletException을 발생시켜 인증 실패를 처리하도록 하였습니다.
- 인증 실패 시 클라이언트에게 401 Unauthorized 상태 코드를 반환하도록 설정하였습니다.

## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
