### PR TITLE
feat: order-api 초기 세팅

### DIFF
--- a/order-api/build.gradle
+++ b/order-api/build.gradle
@@ -1,0 +1,85 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.2.8'
+    id 'io.spring.dependency-management' version '1.1.6'
+}
+
+bootJar { enabled = false }
+jar { enabled = true }
+
+group = 'org.silluck.order'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    set('springCloudVersion', "2023.0.1")
+}
+
+dependencies {
+
+    implementation project(':silluck-domain')
+
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    //redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    testImplementation ('it.ozimov:embedded-redis:0.7.3') {
+        exclude group: "org.slf4j", module: "slf4j-simple"
+    }
+
+    //test 위한 DB
+    testImplementation 'com.h2database:h2'
+
+    //RDB
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    implementation 'mysql:mysql-connector-java:8.0.28'
+
+    //JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    compileOnly 'org.projectlombok:lombok'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+
+    //BaseEntity 사용
+    implementation 'org.springframework.data:spring-data-envers'
+
+    //Swagger
+    implementation 'io.springfox:springfox-swagger-ui:3.0.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/order-api/src/main/java/org/silluck/domain/order/OrderApiApplication.java
+++ b/order-api/src/main/java/org/silluck/domain/order/OrderApiApplication.java
@@ -1,0 +1,21 @@
+package org.silluck.domain.order;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.web.servlet.ServletComponentScan;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.envers.repository.support.EnversRevisionRepositoryFactoryBean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@ServletComponentScan
+@EnableFeignClients
+@SpringBootApplication
+@EnableJpaAuditing
+@EnableJpaRepositories(repositoryFactoryBeanClass = EnversRevisionRepositoryFactoryBean.class)  //  Spring Data JPA 리포지토리를 통해 엔티티의 변경 이력을 조회
+public class OrderApiApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OrderApiApplication.class, args);
+    }
+}

--- a/order-api/src/main/java/org/silluck/domain/order/config/JwtConfig.java
+++ b/order-api/src/main/java/org/silluck/domain/order/config/JwtConfig.java
@@ -1,0 +1,14 @@
+package org.silluck.domain.order.config;
+
+import org.silluck.domain.config.JwtAuthenticationProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JwtConfig {
+
+    @Bean
+    public JwtAuthenticationProvider jwtAuthenticationProvider() {
+        return new JwtAuthenticationProvider();
+    }
+}

--- a/order-api/src/main/java/org/silluck/domain/order/config/RedisConfig.java
+++ b/order-api/src/main/java/org/silluck/domain/order/config/RedisConfig.java
@@ -1,0 +1,27 @@
+package org.silluck.domain.order.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableJpaRepositories
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> restTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+
+        StringRedisSerializer serializer = new StringRedisSerializer();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(serializer);
+        redisTemplate.setValueSerializer(serializer);
+        redisTemplate.setHashKeySerializer(serializer);
+        redisTemplate.setHashValueSerializer(serializer);
+
+        return redisTemplate;
+    }
+}

--- a/order-api/src/main/java/org/silluck/domain/order/exception/CustomException.java
+++ b/order-api/src/main/java/org/silluck/domain/order/exception/CustomException.java
@@ -1,0 +1,20 @@
+package org.silluck.domain.order.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final Integer status;
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    // 커스텀으로 예외처리하여 상태관리에 적합하게
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getDetail());
+        this.errorCode = errorCode;
+        this.status = errorCode.getHttpStatus().value();
+    }
+
+}

--- a/order-api/src/main/java/org/silluck/domain/order/exception/ErrorCode.java
+++ b/order-api/src/main/java/org/silluck/domain/order/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package org.silluck.domain.order.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorCode {
+    NOT_FOUND_ORDER(HttpStatus.BAD_REQUEST, "해당 주문이 존재하지 않습니다.")
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String detail;
+
+}

--- a/order-api/src/main/java/org/silluck/domain/order/exception/ExceptionController.java
+++ b/order-api/src/main/java/org/silluck/domain/order/exception/ExceptionController.java
@@ -1,0 +1,32 @@
+package org.silluck.domain.order.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice   // controller 단으로 들어오는 것 처리
+@Slf4j
+public class ExceptionController {
+
+    @ExceptionHandler({CustomException.class})
+    public ResponseEntity<ExceptionResponse> customRequestException(
+            final CustomException customException) {
+
+        log.warn("api Exception : {}", customException.getErrorCode());
+
+        return ResponseEntity.badRequest().body(new ExceptionResponse
+                (customException.getMessage(), customException.getErrorCode()));
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @ToString   // 정상적이 호출위해
+    public static class ExceptionResponse {
+        private String message;
+        private ErrorCode errorCode;
+    }
+}

--- a/order-api/src/main/resources/application.properties
+++ b/order-api/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=order-api

--- a/order-api/src/main/resources/application.yml
+++ b/order-api/src/main/resources/application.yml
@@ -1,0 +1,37 @@
+server:
+  port: 8082
+
+spring:
+  mvc:
+    path match:
+      matching-strategy: ant_path_matcher
+
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
+      autoconfiguration:
+        jackson:
+          enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    generate-ddl: true
+    show-sql: true
+  #    properties:
+  #      hibernate.format_sql: true
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/order?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${DB_PASSWORD}
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}

--- a/order-api/src/test/java/org/silluck/domain/order/OrderApiApplicationTests.java
+++ b/order-api/src/test/java/org/silluck/domain/order/OrderApiApplicationTests.java
@@ -1,0 +1,13 @@
+package org.silluck.domain.order;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class OrderApiApplicationTests {
+
+    @Test
+    void contextLoads() {
+    }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'time-deal-silluck'
 include 'user-api'
 include 'silluck-domain'
+include 'order-api'


### PR DESCRIPTION
close #
- Order API를 구현하기 위한 초기 설정을 진행했습니다.
- Spring Boot와 관련된 기본적인 설정, JWT 인증, Redis 설정, 예외 처리 관련 구성을 포함합니다.

## 🛰️ Issue Number
#24 

## 작업종류
- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용
1. OrderApiApplication
- @ServletComponentScan
- @EnableFeignClients: 마이크로서비스 간의 통신
- @EnableJpaAuditing: 엔티티의 생성 및 수정 시 자동 시간 기록
- @EnableJpaRepositories: Envers를 통해 엔티티의 변경 이력을 관리합니다.

2. JwtConfig 클래스 추가
- JWT를 통한 인증 기능 필요.

3. RedisConfig 클래스 추가
- RedisTemplate을 통해 Redis에 데이터를 저장하고 조회할 수 있도록 설정.
- 모든 Redis 키와 값(기본, 해시)에 대해 StringRedisSerializer를 사용하여 직렬화.

4. CustomException 클래스 추가
- CustomException 클래스를 추가하여 주문 API에서 발생할 수 있는 예외를 처리.
- ErrorCode와 HTTP 상태 코드를 함께 관리하여 에러 처리.

5. ErrorCode Enum 추가
- Order API에서 사용될 에러 코드를 정의한 Enum을 추가, 필요한 경우 확장 가능.

6. ExceptionController 클래스 추가
- @ControllerAdvice를 통해 전역적으로 예외 처리.
- CustomException 발생 시 클라이언트에게 적절한 에러 메시지를 반환.

## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
