### PR TITLE
feat: 상품 및 상품 아이템 수정

### DIFF
--- a/order-api/scratch_order.http
+++ b/order-api/scratch_order.http
@@ -24,6 +24,38 @@ X-AUTH-TOKEN: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJZdVp5SEI5c3d0UjFBdnRGSmg2d1drclVwM
 {
   "productId": 1,
   "count": 1,
-  "name": "덩크 검빨",
+  "name": "덩크 검흰",
+  "price": 100000
+}
+
+### 상품 수정 (셀러)
+PUT http://localhost:8082/seller/product
+Content-Type: application/json
+X-AUTH-TOKEN: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJZdVp5SEI5c3d0UjFBdnRGSmg2d1drclVwMTlDbDBGYy9BbXI4TjVwQ1hVPSIsImp0aSI6ImptaXhNb2hQbjY2V3c0S3ZMQVdjalE9PSIsInJvbGVzIjoiUk9MRV9TRUxMRVIiLCJpYXQiOjE3MjM3MzE0NjMsImV4cCI6MTcyMzgxNzg2M30.G7kxqXGSAsL8CnX0N6fD1IbqI2BxC9eE8Te4ftuZeMN2afX3-97sK6bWlWEi6uwRfjq_QALjW3__TNY2D8NNhw
+
+{
+  "description": "나이키 운동화",
+  "items": [
+    {
+      "id": 1,
+      "count": 10,
+      "name": "덩크 검빨",
+      "price": 100000
+    }
+  ],
+  "id": 1,
+  "name": "나이키 덩크"
+}
+
+### 상품 아이템 수정 (셀러)
+PUT http://localhost:8082/seller/product/item
+Content-Type: application/json
+X-AUTH-TOKEN: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJZdVp5SEI5c3d0UjFBdnRGSmg2d1drclVwMTlDbDBGYy9BbXI4TjVwQ1hVPSIsImp0aSI6ImptaXhNb2hQbjY2V3c0S3ZMQVdjalE9PSIsInJvbGVzIjoiUk9MRV9TRUxMRVIiLCJpYXQiOjE3MjM3MzE0NjMsImV4cCI6MTcyMzgxNzg2M30.G7kxqXGSAsL8CnX0N6fD1IbqI2BxC9eE8Te4ftuZeMN2afX3-97sK6bWlWEi6uwRfjq_QALjW3__TNY2D8NNhw
+
+{
+  "id" : 1,
+  "productId": 1,
+  "count": 10,
+  "name": "덩크 검빨 2",
   "price": 100000
 }

--- a/order-api/src/main/java/org/silluck/domain/order/controller/SellerProductController.java
+++ b/order-api/src/main/java/org/silluck/domain/order/controller/SellerProductController.java
@@ -5,7 +5,10 @@ import org.silluck.domain.config.JwtAuthenticationProvider;
 import org.silluck.domain.domain.common.UserVo;
 import org.silluck.domain.order.domain.dto.request.AddProductForm;
 import org.silluck.domain.order.domain.dto.request.AddProductItemForm;
+import org.silluck.domain.order.domain.dto.request.UpdateProductForm;
+import org.silluck.domain.order.domain.dto.request.UpdateProductItemForm;
 import org.silluck.domain.order.domain.dto.response.ProductDTO;
+import org.silluck.domain.order.domain.dto.response.ProductItemDTO;
 import org.silluck.domain.order.service.ProductItemService;
 import org.silluck.domain.order.service.ProductService;
 import org.springframework.http.ResponseEntity;
@@ -38,5 +41,25 @@ public class SellerProductController {
         UserVo userVo = provider.getUserVo(token);
         return ResponseEntity.ok(ProductDTO.from(
                 productItemService.addProductItem(userVo.getId(), form)));
+    }
+
+    @PutMapping
+    public ResponseEntity<ProductDTO> updateProduct(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestBody UpdateProductForm form) {
+
+        UserVo userVo = provider.getUserVo(token);
+        return ResponseEntity.ok(ProductDTO.from(
+                productService.updateProduct(userVo.getId(), form)));
+    }
+
+    @PutMapping("/item")
+    public ResponseEntity<ProductItemDTO> updateProductItem(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestBody UpdateProductItemForm form) {
+
+        UserVo userVo = provider.getUserVo(token);
+        return ResponseEntity.ok(ProductItemDTO.from(
+                productItemService.updateProductItem(userVo.getId(), form)));
     }
 }

--- a/order-api/src/main/java/org/silluck/domain/order/domain/dto/request/UpdateProductForm.java
+++ b/order-api/src/main/java/org/silluck/domain/order/domain/dto/request/UpdateProductForm.java
@@ -1,0 +1,19 @@
+package org.silluck.domain.order.domain.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProductForm {
+    private String id;  // product Id
+    private String name;
+    private String description;
+    private List<UpdateProductItemForm> items;
+}

--- a/order-api/src/main/java/org/silluck/domain/order/domain/dto/request/UpdateProductItemForm.java
+++ b/order-api/src/main/java/org/silluck/domain/order/domain/dto/request/UpdateProductItemForm.java
@@ -1,0 +1,18 @@
+package org.silluck.domain.order.domain.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateProductItemForm {
+    private Long id;        // productItem Id
+    private Long productId;
+    private String name;
+    private Integer price;
+    private Integer count;
+}

--- a/order-api/src/main/java/org/silluck/domain/order/domain/entity/Product.java
+++ b/order-api/src/main/java/org/silluck/domain/order/domain/entity/Product.java
@@ -1,10 +1,7 @@
 package org.silluck.domain.order.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 import org.hibernate.envers.Audited;
 import org.silluck.domain.order.domain.dto.request.AddProductForm;
@@ -13,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/order-api/src/main/java/org/silluck/domain/order/domain/entity/ProductItem.java
+++ b/order-api/src/main/java/org/silluck/domain/order/domain/entity/ProductItem.java
@@ -1,15 +1,13 @@
 package org.silluck.domain.order.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.hibernate.envers.AuditOverride;
 import org.hibernate.envers.Audited;
 import org.silluck.domain.order.domain.dto.request.AddProductItemForm;
 
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/order-api/src/main/java/org/silluck/domain/order/exception/ErrorCode.java
+++ b/order-api/src/main/java/org/silluck/domain/order/exception/ErrorCode.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     NOT_FOUND_PRODUCT(HttpStatus.BAD_REQUEST, "해당 상품이 존재하지 않습니다."),
-    SAME_ITEM_NAME(HttpStatus.BAD_REQUEST, "같은 이름의 상품이 존재합니다."),
+    NOT_FOUND_ITEM(HttpStatus.BAD_REQUEST, "해당 아이템이 존재하지 않습니다."),
+    SAME_ITEM_NAME(HttpStatus.BAD_REQUEST, "같은 이름의 아이템이 존재합니다."),
 
     NOT_FOUND_ORDER(HttpStatus.BAD_REQUEST, "해당 주문이 존재하지 않습니다.")
     ;

--- a/order-api/src/main/java/org/silluck/domain/order/service/ProductItemService.java
+++ b/order-api/src/main/java/org/silluck/domain/order/service/ProductItemService.java
@@ -2,6 +2,7 @@ package org.silluck.domain.order.service;
 
 import lombok.RequiredArgsConstructor;
 import org.silluck.domain.order.domain.dto.request.AddProductItemForm;
+import org.silluck.domain.order.domain.dto.request.UpdateProductItemForm;
 import org.silluck.domain.order.domain.entity.Product;
 import org.silluck.domain.order.domain.entity.ProductItem;
 import org.silluck.domain.order.exception.CustomException;
@@ -10,8 +11,7 @@ import org.silluck.domain.order.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.silluck.domain.order.exception.ErrorCode.NOT_FOUND_PRODUCT;
-import static org.silluck.domain.order.exception.ErrorCode.SAME_ITEM_NAME;
+import static org.silluck.domain.order.exception.ErrorCode.*;
 
 @Service
 @RequiredArgsConstructor
@@ -34,5 +34,16 @@ public class ProductItemService {
         product.getProductItems().add(productItem);
 
         return product;
+    }
+
+    @Transactional
+    public ProductItem updateProductItem(Long sellerId, UpdateProductItemForm form) {
+        ProductItem productItem = productItemRepository.findById(form.getId())
+                .filter(pi -> pi.getSellerId().equals(sellerId))
+                .orElseThrow(() -> new CustomException(NOT_FOUND_ITEM));
+        productItem.setName(form.getName());
+        productItem.setCount(form.getCount());
+        productItem.setPrice(form.getPrice());
+        return productItem;
     }
 }

--- a/order-api/src/main/java/org/silluck/domain/order/service/ProductService.java
+++ b/order-api/src/main/java/org/silluck/domain/order/service/ProductService.java
@@ -2,10 +2,17 @@ package org.silluck.domain.order.service;
 
 import lombok.RequiredArgsConstructor;
 import org.silluck.domain.order.domain.dto.request.AddProductForm;
+import org.silluck.domain.order.domain.dto.request.UpdateProductForm;
+import org.silluck.domain.order.domain.dto.request.UpdateProductItemForm;
 import org.silluck.domain.order.domain.entity.Product;
+import org.silluck.domain.order.domain.entity.ProductItem;
+import org.silluck.domain.order.exception.CustomException;
 import org.silluck.domain.order.repository.ProductRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static org.silluck.domain.order.exception.ErrorCode.NOT_FOUND_ITEM;
+import static org.silluck.domain.order.exception.ErrorCode.NOT_FOUND_PRODUCT;
 
 @Service
 @RequiredArgsConstructor
@@ -16,6 +23,25 @@ public class ProductService {
     @Transactional
     public Product addProduct(Long sellerId, AddProductForm form) {
         return productRepository.save(Product.of(sellerId, form));
+    }
+
+    @Transactional
+    public Product updateProduct(Long sellerId, UpdateProductForm form) {
+        Product product = productRepository.findBySellerIdAndId(sellerId, Long.valueOf(form.getId()))
+                .orElseThrow(() -> new CustomException(NOT_FOUND_PRODUCT));
+
+        product.setName(form.getName());
+        product.setDescription(form.getDescription());
+
+        for (UpdateProductItemForm itemForm : form.getItems()) {
+            ProductItem productItem = product.getProductItems().stream().filter(
+                            pi -> pi.getId().equals(itemForm.getId()))
+                    .findFirst().orElseThrow(() -> new CustomException(NOT_FOUND_ITEM));
+            productItem.setName(itemForm.getName());
+            productItem.setCount(itemForm.getCount());
+            productItem.setPrice(itemForm.getPrice());
+        }
+        return product;
     }
 
 }


### PR DESCRIPTION
close #
- 셀러가 상품과 상품 아이템을 수정할 수 있는 기능을 추가했습니다.
- ProductService와 ProductItemService를 통해 상품 및 상품 아이템의 수정을 할 수 있습니다.

## 🛰️ Issue Number
#26 

## 작업종류
- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용
1. 상품 수정 기능
- 엔드포인트: PUT /seller/product
- 셀러가 기존의 상품 정보를 수정할 수 있는 기능.
- 상품의 이름, 설명, 그리고 관련된 상품 아이템 수정.
- 주요 클래스 및 메서드:
    - UpdateProductForm: 상품 수정을 위한 폼 객체.
    - ProductService.updateProduct() : 셀러 ID와 상품 ID를 기반으로 상품 수정. (연관된 상품 아이템들도 함께 수정 가능)

2. 상품 아이템 수정 기능
- 엔드포인트: PUT /seller/product/item
- 셀러가 기존의 상품 아이템 정보를 수정할 수 있는 기능.
- 상품 아이템의 이름, 가격, 수량 등을 수정.
- 주요 클래스:
    - UpdateProductItemForm: 상품 아이템 수정을 위한 폼 객체.
    - ProductItemService.updateProductItem() : 상품 아이템 ID와 셀러 ID를 기반으로 상품 아이템 수정.

## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
