### PR TITLE
feat: 상품 삭제

### DIFF
--- a/order-api/scratch_order.http
+++ b/order-api/scratch_order.http
@@ -59,3 +59,13 @@ X-AUTH-TOKEN: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJZdVp5SEI5c3d0UjFBdnRGSmg2d1drclVwM
   "name": "덩크 검빨 2",
   "price": 100000
 }
+
+### 상품 삭제 (셀러)
+DELETE http://localhost:8082/seller/product?id=1
+Content-Type: application/json
+X-AUTH-TOKEN: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJZdVp5SEI5c3d0UjFBdnRGSmg2d1drclVwMTlDbDBGYy9BbXI4TjVwQ1hVPSIsImp0aSI6ImptaXhNb2hQbjY2V3c0S3ZMQVdjalE9PSIsInJvbGVzIjoiUk9MRV9TRUxMRVIiLCJpYXQiOjE3MjM3MzE0NjMsImV4cCI6MTcyMzgxNzg2M30.G7kxqXGSAsL8CnX0N6fD1IbqI2BxC9eE8Te4ftuZeMN2afX3-97sK6bWlWEi6uwRfjq_QALjW3__TNY2D8NNhw
+
+### 상품 아이템 삭제 (셀러)
+DELETE http://localhost:8082/seller/product/item?id=2
+Content-Type: application/json
+X-AUTH-TOKEN: eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJZdVp5SEI5c3d0UjFBdnRGSmg2d1drclVwMTlDbDBGYy9BbXI4TjVwQ1hVPSIsImp0aSI6ImptaXhNb2hQbjY2V3c0S3ZMQVdjalE9PSIsInJvbGVzIjoiUk9MRV9TRUxMRVIiLCJpYXQiOjE3MjM3MzE0NjMsImV4cCI6MTcyMzgxNzg2M30.G7kxqXGSAsL8CnX0N6fD1IbqI2BxC9eE8Te4ftuZeMN2afX3-97sK6bWlWEi6uwRfjq_QALjW3__TNY2D8NNhw

--- a/order-api/src/main/java/org/silluck/domain/order/controller/SellerProductController.java
+++ b/order-api/src/main/java/org/silluck/domain/order/controller/SellerProductController.java
@@ -62,4 +62,25 @@ public class SellerProductController {
         return ResponseEntity.ok(ProductItemDTO.from(
                 productItemService.updateProductItem(userVo.getId(), form)));
     }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteProduct(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam Long id) {
+
+        UserVo userVo = provider.getUserVo(token);
+        productService.deleteProduct(userVo.getId(), id);
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/item")
+    public ResponseEntity<Void> deleteProductItem(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestParam Long id) {
+
+        UserVo userVo = provider.getUserVo(token);
+        productItemService.deleteProductItem(userVo.getId(), id);
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/order-api/src/main/java/org/silluck/domain/order/domain/entity/ProductItem.java
+++ b/order-api/src/main/java/org/silluck/domain/order/domain/entity/ProductItem.java
@@ -26,7 +26,7 @@ public class ProductItem extends BaseEntity {
     private Integer price;
     private Integer count;
 
-    @ManyToOne(cascade = CascadeType.ALL)
+    @ManyToOne
     @JoinColumn(name = "product_id")
     private Product product;
 

--- a/order-api/src/main/java/org/silluck/domain/order/service/ProductItemService.java
+++ b/order-api/src/main/java/org/silluck/domain/order/service/ProductItemService.java
@@ -46,4 +46,12 @@ public class ProductItemService {
         productItem.setPrice(form.getPrice());
         return productItem;
     }
+
+    @Transactional
+    public void deleteProductItem(Long sellerId, Long productItemId) {
+        ProductItem productItem = productItemRepository.findById(productItemId)
+                .filter(pr -> pr.getSellerId().equals(sellerId))
+                .orElseThrow(() -> new CustomException(NOT_FOUND_ITEM));
+        productItemRepository.delete(productItem);
+    }
 }

--- a/order-api/src/main/java/org/silluck/domain/order/service/ProductService.java
+++ b/order-api/src/main/java/org/silluck/domain/order/service/ProductService.java
@@ -44,4 +44,11 @@ public class ProductService {
         return product;
     }
 
+    @Transactional
+    public void deleteProduct(Long sellerId, Long productId) {
+        Product product = productRepository.findBySellerIdAndId(sellerId, productId)
+                .orElseThrow(() -> new CustomException(NOT_FOUND_PRODUCT));
+        productRepository.delete(product);
+    }
+
 }


### PR DESCRIPTION
close #

- 셀러가 상품 및 상품 아이템을 삭제할 수 있는 기능을 추가했습니다.
- ProductService와 ProductItemService를 통해 상품 및 상품 아이템의 삭제 할 수 있습니다.

## 🛰️ Issue Number
#27 

## 작업종류

- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용
1. 상품 삭제 기능
- 엔드포인트: DELETE /seller/product
- 셀러가 등록한 상품을 삭제할 수 있는 기능.
- 해당 상품의 ID를 기반으로 삭제.
- 주요 메서드
    - ProductService.deleteProduct(): 셀러 ID와 상품 ID를 기반으로 상품 삭제.

2. 상품 아이템 삭제 기능

- 엔드포인트: DELETE /seller/product/item
- 셀러가 등록한 특정 상품 아이템을 삭제할 수 있는 기능.
- 해당 상품 아이템의 ID를 기반으로 삭제.
- 주요 메서드
    - ProductItemService.deleteProductItem(): 셀러 ID와 상품 아이템 ID를 기반으로 상품 아이템 삭제.

3. 연관 관계 변경
- ProductItem 엔티티에서 Product와의 관계 수정 -> cascade = CascadeType.ALL 옵션 제거.
- 상품 아이템 삭제 시 상품 자체가 삭제되지 않게 -> 위로 전파되는 것 방지.
## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
