### PR TITLE
feat: wishlist (장바구니) 조회 기능 구현

### DIFF
--- a/order-api/src/main/java/org/silluck/domain/order/application/WishlistApplication.java
+++ b/order-api/src/main/java/org/silluck/domain/order/application/WishlistApplication.java
@@ -10,6 +10,9 @@ import org.silluck.domain.order.service.ProductSearchService;
 import org.silluck.domain.order.service.WishlistService;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -37,25 +40,160 @@ public class WishlistApplication {
         if (wishlist != null && !addAble(wishlist, product, form)) {
             throw new CustomException(ITEM_COUNT_NOT_ENOUGH);
         }
+
         return wishlistService.addProductInWishlist(customerId, form);
     }
 
+    /**
+     * 1. 장바구니에 상품 추가
+     * 2. 상품의 가격이나 수량이 변동된다.
+     * 3. 변동 되면 그것을 빼주거나하는 등 어떤 처리가 필요하다.
+     */
+    public Wishlist getWishlist(Long customerId) {
+        /**
+         * - 조회하는 순간 메시지를 읽었다고 판단 메시지 삭제
+         * 1. response 에서는 메시지가 함께 나간다.
+         * 2. redis 에 저장할 때는 메시지가 없어야 한다.
+         */
+        Wishlist wishlist = refreshWishlist(wishlistService.getWishlist(customerId));
+
+        Wishlist returnWishlist = new Wishlist();
+        returnWishlist.setCustomerId(customerId);
+        returnWishlist.setProducts(wishlist.getProducts());
+        returnWishlist.setMessages(wishlist.getMessages());
+
+        wishlist.setMessages(new ArrayList<>());
+        wishlistService.putWishlist(customerId, wishlist);
+
+        return returnWishlist;
+    }
+
+    private Wishlist refreshWishlist(Wishlist wishlist) {
+        /**
+         * 1. 상품이나 상품 아이템 정보, 가격, 수량 변경 체크 그에 맞는 알람 제공
+         * 2. 바뀐 데이터 임의로 변경
+         * 3. 메시지를 보고 난 다음에는, 이미 본 메시지는 삭제 필요
+         */
+        // 현재 db에 있는 상품들
+        Map<Long, Product> curProductMap = productSearchService
+                .getListByProductIds(wishlist.getProducts().stream()
+                        .map(Wishlist.Product::getId).toList()).stream()
+                .collect(Collectors.toMap(Product::getId, product -> product));
+
+        for (int i = 0; i < wishlist.getProducts().size(); i++) {
+            // 위시리스트에 있는 상품
+            Wishlist.Product wishlistProduct = wishlist.getProducts().get(i);
+            // 현재 db에 있는 상품
+            Product curProduct = curProductMap.get(wishlistProduct.getId());
+
+            // 현재 db에 그 상품이 없는 경우
+            if (curProduct == null) {
+                wishlist.getProducts().remove(wishlistProduct);
+                i--;
+                wishlist.addMessage(wishlistProduct.getName() + "상품이 삭제되었습니다.");
+                continue;
+            }
+
+            // 현재 db에 있는 상품 아이템들
+            Map<Long, ProductItem> curProductItemMap = curProduct.getProductItems()
+                    .stream().collect(Collectors.toMap(
+                            ProductItem::getId, productItem -> productItem));
+
+            // 에러 케이스가 발생할 수 있는 상황들 체크
+            List<String> tempMessages = new ArrayList<>();  // 발생할 수 있는 알림 임시 저장
+            for (int j = 0; j < wishlistProduct.getProductItems().size(); j++) {
+                Wishlist.ProductItem wishlistProductItem
+                        = wishlistProduct.getProductItems().get(j);
+                ProductItem curProductItem
+                        = curProductItemMap.get(wishlistProductItem.getId());
+
+                // 현재 그 상품 아이템이 없는 경우
+                if (curProductItem == null) {
+                    wishlistProduct.getProductItems().remove(wishlistProductItem);
+                    j--;
+                    tempMessages.add(wishlistProductItem.getName()
+                            + " 옵션(아이템)이 삭제되었습니다.");
+                    continue;
+                }
+
+                boolean isPriceChanged = false;
+                boolean isCountNotEnough = false;
+                // 가격 변동이 있는 경우
+                if (!wishlistProductItem.getPrice().equals(curProductItem.getPrice())) {
+                    isPriceChanged = true;
+                    wishlistProductItem.setPrice(curProductItem.getPrice());
+                }
+                // 현재 수량이 모자라는 경우
+                if (wishlistProductItem.getCount() > curProductItem.getCount()) {
+                    isCountNotEnough = true;
+                    wishlistProductItem.setCount(curProductItem.getCount());
+                }
+                if (isPriceChanged && isCountNotEnough) {
+                    // 1번 경우 : 가격 변동 및 수량 부족
+                    tempMessages.add(wishlistProductItem.getName()
+                            + " 가격 변경 및 수량이 가능한 최대로 변경되었습니다.");
+                } else if (isPriceChanged) {
+                    // 2번 경우 : 가격 변동
+                    tempMessages.add(wishlistProductItem.getName()
+                            + " 가격이 변경되었습니다.");
+                } else if (isCountNotEnough) {
+                    // 3번 경우 : 수량 부족
+                    tempMessages.add(wishlistProductItem.getName()
+                            + " 수량이 가능한 최대로 변경되었습니다.");
+                }
+            }
+            // 위시리스트(장바구니)에 있던 상품 아이템 모두 구매 불가한 경우 (아이템 자체가 없어져서)
+            // 품절인 경우와는 다른 경우
+            if (wishlistProduct.getProductItems().isEmpty()) {
+                wishlist.getProducts().remove(wishlistProduct);
+                i--;
+                wishlist.addMessage(wishlistProduct.getName()
+                        + " 상품 옵션(아이템)이 현재 존재하지 않아 구매할 수 없습니다.");
+            }
+            // 변동 사항 있으면 메시지 알림
+            else if (!tempMessages.isEmpty()) {
+                StringBuilder sb = new StringBuilder();
+                sb.append(wishlistProduct.getName()).append(" 상품 번동 사항 : ");
+                for (String message : tempMessages) {
+                    sb.append(message).append(", ");
+                }
+                wishlist.addMessage(sb.toString().trim());
+            }
+        }
+        wishlistService.putWishlist(wishlist.getCustomerId(), wishlist);
+        return wishlist;
+    }
+
+    public void clearWishlist(Long customerId) {
+        wishlistService.putWishlist(customerId, null);
+    }
+
     private boolean addAble(Wishlist wishlist, Product product, AddProductInWishlistForm form) {
-        Wishlist.Product wishListProduct = wishlist.getProducts().stream().filter(p -> p.getId().equals(form.getId()))
-                .findFirst().orElseThrow(() -> new CustomException(NOT_FOUND_PRODUCT));
+
+        Wishlist.Product wishListProduct = wishlist.getProducts().stream()
+                .filter(p -> p.getId().equals(form.getId())).findFirst()
+                .orElse(Wishlist.Product.builder()
+                        .id(product.getId())
+                        .productItems(Collections.emptyList())
+                        .build());
 
         Map<Long, Integer> wishListItemCountMap = wishListProduct.getProductItems()
                 .stream().collect(Collectors.toMap(
                         Wishlist.ProductItem::getId, Wishlist.ProductItem::getCount));
 
-        Map<Long, Integer> curItemCountMap = product.getProductItems()
-                .stream().collect(Collectors.toMap(ProductItem::getId, ProductItem::getCount));
+        Map<Long, Integer> curItemCountMap = product.getProductItems().stream()
+                .collect(Collectors.toMap(ProductItem::getId, ProductItem::getCount));
 
         return form.getProductItems().stream().noneMatch(
                 formItem -> {
-                    Integer wishlistCount = wishListItemCountMap.get(formItem.getId());
-                    Integer curCount = curItemCountMap.get(formItem.getId());
-                     return (formItem.getCount() + wishlistCount > curCount);
+                    Integer wishlistCount =
+                            wishListItemCountMap.get(formItem.getId()) == null ? 0
+                                    : wishListItemCountMap.get(formItem.getId());
+
+                    Integer curCount = curItemCountMap.get(formItem.getId()) == null ? 0
+                            : curItemCountMap.get(formItem.getId());
+
+                    return (formItem.getCount() + wishlistCount > curCount);
                 });
     }
 }

--- a/order-api/src/main/java/org/silluck/domain/order/controller/CustomerWishlistController.java
+++ b/order-api/src/main/java/org/silluck/domain/order/controller/CustomerWishlistController.java
@@ -22,8 +22,14 @@ public class CustomerWishlistController {
             @RequestHeader(name = "X-AUTH-TOKEN") String token,
             @RequestBody AddProductInWishlistForm form) {
         UserVo userVo = provider.getUserVo(token);
-        Wishlist wishlist = wishlistApplication
-                .addProductInWishlist(userVo.getId(), form);
-        return ResponseEntity.ok(wishlist);
+        return ResponseEntity.ok(wishlistApplication
+                .addProductInWishlist(userVo.getId(), form));
+    }
+
+    @GetMapping
+    public ResponseEntity<Wishlist> getWishlist(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token) {
+        UserVo userVo = provider.getUserVo(token);
+        return ResponseEntity.ok(wishlistApplication.getWishlist(userVo.getId()));
     }
 }

--- a/order-api/src/main/java/org/silluck/domain/order/domain/redis/Wishlist.java
+++ b/order-api/src/main/java/org/silluck/domain/order/domain/redis/Wishlist.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 @Data
 @NoArgsConstructor
+@AllArgsConstructor
 @RedisHash("wishlist")  // key의 prefix 설정
 public class Wishlist {
     @Id
@@ -20,6 +21,10 @@ public class Wishlist {
     private List<Product> products = new ArrayList<>();
     // 장바구니 안 상품 정보가 바뀌었을 때 알려주는 메시지
     private List<String> messages = new ArrayList<>();
+
+    public Wishlist(Long customerId) {
+        this.customerId = customerId;
+    }
 
     public void addMessage(String message) {
         messages.add(message);
@@ -73,4 +78,7 @@ public class Wishlist {
         }
     }
 
+    public Wishlist clone() {
+        return new Wishlist(customerId, products, messages);
+    }
 }

--- a/order-api/src/main/java/org/silluck/domain/order/repository/ProductRepository.java
+++ b/order-api/src/main/java/org/silluck/domain/order/repository/ProductRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +16,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
 
     @EntityGraph(attributePaths = {"productItems"}, type = EntityGraph.EntityGraphType.LOAD)
     Optional<Product> findBySellerIdAndId(Long sellerId, Long Id);
+
+    @EntityGraph(attributePaths = {"productItems"}, type = EntityGraph.EntityGraphType.LOAD)
+    List<Product> findAllByIdIn(List<Long> ids);
 }

--- a/order-api/src/main/java/org/silluck/domain/order/service/ProductSearchService.java
+++ b/order-api/src/main/java/org/silluck/domain/order/service/ProductSearchService.java
@@ -29,6 +29,6 @@ public class ProductSearchService {
     }
 
     public List<Product> getListByProductIds(List<Long> productIds) {
-        return productRepository.findAllById(productIds);
+        return productRepository.findAllByIdIn(productIds);
     }
 }

--- a/order-api/src/main/java/org/silluck/domain/order/service/WishlistService.java
+++ b/order-api/src/main/java/org/silluck/domain/order/service/WishlistService.java
@@ -25,7 +25,13 @@ public class WishlistService {
     private final RedisClient redisClient;
 
     public Wishlist getWishlist(Long customerId) {
-        return redisClient.get(customerId, Wishlist.class);
+        Wishlist wishlist = redisClient.get(customerId, Wishlist.class);
+        return wishlist == null ? new Wishlist() : wishlist;
+    }
+
+    public Wishlist putWishlist(Long customerId, Wishlist wishlist) {
+        redisClient.put(customerId, wishlist);
+        return wishlist;
     }
 
     public Wishlist addProductInWishlist(Long customerId, AddProductInWishlistForm form) {
@@ -43,6 +49,7 @@ public class WishlistService {
          */
         Optional<Wishlist.Product> productOptional = wishlist.getProducts()
                 .stream().filter(p -> p.getId().equals(form.getId())).findFirst();
+
         if (productOptional.isPresent()) {
             Wishlist.Product redisProduct = productOptional.get();
 

--- a/order-api/src/test/java/org/silluck/domain/order/application/WishlistApplicationTest.java
+++ b/order-api/src/test/java/org/silluck/domain/order/application/WishlistApplicationTest.java
@@ -1,0 +1,115 @@
+package org.silluck.domain.order.application;
+
+import org.junit.jupiter.api.Test;
+import org.silluck.domain.config.JwtAuthenticationProvider;
+import org.silluck.domain.order.domain.dto.request.AddProductForm;
+import org.silluck.domain.order.domain.dto.request.AddProductInWishlistForm;
+import org.silluck.domain.order.domain.dto.request.AddProductItemForm;
+import org.silluck.domain.order.domain.entity.Product;
+import org.silluck.domain.order.domain.entity.ProductItem;
+import org.silluck.domain.order.domain.redis.Wishlist;
+import org.silluck.domain.order.repository.ProductRepository;
+import org.silluck.domain.order.service.ProductService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest()
+@TestPropertySource(properties = {
+        "JWT_SECRET_KEY=testSecretKey"
+})
+class WishlistApplicationTest {
+
+    @Autowired
+    private WishlistApplication wishlistApplication;
+    @Autowired
+    private ProductService productService;
+    @Autowired
+    private ProductRepository productRepository;
+    @Autowired
+    private JwtAuthenticationProvider jwtAuthenticationProvider;
+
+    @Test
+    void ADD_PRODUCT_IN_WISHLIST_TEST() {
+
+        Long customerId = 100L;
+
+        wishlistApplication.clearWishlist(customerId);
+
+        Product product = addProduct();
+        Product result = productRepository.findWithProductItemsById(product.getId()).get();
+
+        // wishlist에 상품 추가
+        Wishlist wishlist = wishlistApplication.addProductInWishlist(
+                customerId, makeAddProductForm(result));
+        // 데이터가 검증이 들어갔는지 테스트 필요
+        assertEquals(wishlist.getMessages().size(), 0);
+
+        wishlist = wishlistApplication.getWishlist(customerId);
+        assertEquals(wishlist.getMessages().size(), 1);
+
+
+        product.getProductItems().get(0).setCount(0);
+        productRepository.save(product);
+    }
+
+    private AddProductInWishlistForm makeAddProductForm(Product product) {
+        // 상품 아이템 중 1개
+        ProductItem pi = product.getProductItems().get(0);
+        // 위시리스트에 담기는 상품 아이템 생성
+        AddProductInWishlistForm.ProductItem productItem =
+                AddProductInWishlistForm.ProductItem.builder()
+                        .id(pi.getId())
+                        .sellerId(pi.getSellerId())
+                        .name(pi.getName())
+                        .count(5)
+                        .price(20000)
+                        .build();
+        // 반환
+        return AddProductInWishlistForm.builder()
+                .id(product.getId())
+                .sellerId(product.getSellerId())
+                .name(product.getName())
+                .description(product.getDescription())
+                .productItems(List.of(productItem))
+                .build();
+    }
+
+    private Product addProduct() {
+        Long sellerId = 1L;
+
+        AddProductForm form = makeProductForm("나이키 에어포스 1", "나이키 운동화", 3);
+
+        return productService.addProduct(sellerId, form);
+    }
+
+
+    private static AddProductForm makeProductForm(
+            String name, String description, int itemCount) {
+        List<AddProductItemForm> itemForms = new ArrayList<>();
+        for (int i = 0; i < itemCount; i++) {
+            itemForms.add(makeProductItemForm(null, name + i));
+        }
+        return AddProductForm.builder()
+                .name(name)
+                .description(description)
+                .items(itemForms)
+                .build();
+    }
+
+    private static AddProductItemForm makeProductItemForm(
+            Long productId, String name) {
+        return AddProductItemForm.builder()
+                .productId(productId)
+                .name(name)
+                .price(50000)
+                .count(10)
+                .build();
+    }
+
+}

--- a/order-api/src/test/java/org/silluck/domain/order/service/ProductServiceTest.java
+++ b/order-api/src/test/java/org/silluck/domain/order/service/ProductServiceTest.java
@@ -5,10 +5,10 @@ import org.silluck.domain.config.JwtAuthenticationProvider;
 import org.silluck.domain.order.domain.dto.request.AddProductForm;
 import org.silluck.domain.order.domain.dto.request.AddProductItemForm;
 import org.silluck.domain.order.domain.entity.Product;
-import org.silluck.domain.order.domain.entity.ProductItem;
 import org.silluck.domain.order.repository.ProductRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,6 +17,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
+@TestPropertySource(properties = {
+        "JWT_SECRET_KEY=testSecretKey"
+})
 class ProductServiceTest {
 
     @Autowired

--- a/order-api/src/test/resources/application.yml
+++ b/order-api/src/test/resources/application.yml
@@ -1,5 +1,6 @@
 server:
   port: 8082
+  shutdown: graceful
 
 spring:
   mvc:


### PR DESCRIPTION
close #

- 고객이 Wishlist(장바구니)를 조회할 수 있는 기능을 추가했습니다.
- 장바구니 조회 시 상품 정보의 변동 사항(가격, 수량, 삭제 여부 등)을 체크하고, 알림 메시지를 제공합니다.
- Redis를 통해 저장된 장바구니 데이터를 조회하고 최신 상태로 업데이트합니다.

## 🛰️ Issue Number
#30 

## 작업종류
- [x] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [x] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용

1. 장바구니 조회 기능 구현
- WishlistApplication.getWishlist(Long customerId) : 고객 자신의 장바구니를 조회.
- 조회 시점에서 상품의 최신 정보를 반영하고, 장바구니 내 상품의 상태 변화(예: 아이템 삭제 여부, 가격 변동, 수량 부족 등)에 따라 고객에게 알림 메세지 전달.

2. 상품 정보 갱신 및 알림 메시지 처리
- WishlistApplication.refreshWishlist() : 장바구니에 있는 상품 정보와 현재 DB에 저장된 상품 정보를 비교하여 최신화.
- 가격 변동, 수량 부족, 상품 삭제 등의 상황에서 사용자가 알 수 있도록 메시지를 생성하고, 해당 메시지는 장바구니에 포함되어 반환.
- 조회 이후에는 해당 메시지 삭제. (redis에 저장 시 message 빈 값으로 저장)

3. API 엔드포인트
- 엔드포인트: GET /customer/wishlist
```
{
  "customerId": 100,
  "products": [
    {
      "id": 1,
      "name": "Example Product",
      "description": "This is an example product",
      "productItems": [
        {
          "id": 101,
          "name": "Example Item",
          "price": 20000,
          "count": 3
        }
      ]
    }
  ],
  "messages": [
    "Example Item 가격이 변경되었습니다.",
    "Example Item 수량이 가능한 최대로 변경되었습니다."
  ]
}
```

4. 테스트 코드 추가
- 장바구니 조회 기능 간단한 테스트를 추가.
- JPA의 일괄적 Lazy 선언으로 인한 테스트 코드에서 발생하는 에러 처리를 위해 QueryDsl 사용하여 하위 엔티티까지 조회 
- 컬럼까지 확인 하는 테스트 보강 필요.

5. 일부 코드 NullpointExecption 방치 처리

## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
