### PR TITLE
feat: wishlist (장바구니) 수정 기능 구현

### DIFF
--- a/order-api/src/main/java/org/silluck/domain/order/application/WishlistApplication.java
+++ b/order-api/src/main/java/org/silluck/domain/order/application/WishlistApplication.java
@@ -45,6 +45,17 @@ public class WishlistApplication {
     }
 
     /**
+     * 엣지 케이스 처리
+     * 실직적으로 변하는 테이터 : 상품 삭제, 수량 변경
+     * wishlist refresh 작업 이미 구현
+     * wishlist 조회 로직 재사용
+     */
+    public Wishlist updateWishlist(Long customerId, Wishlist wishlist) {
+        wishlistService.putWishlist(customerId, wishlist);
+        return getWishlist(customerId);
+    }
+
+    /**
      * 1. 장바구니에 상품 추가
      * 2. 상품의 가격이나 수량이 변동된다.
      * 3. 변동 되면 그것을 빼주거나하는 등 어떤 처리가 필요하다.

--- a/order-api/src/main/java/org/silluck/domain/order/controller/CustomerWishlistController.java
+++ b/order-api/src/main/java/org/silluck/domain/order/controller/CustomerWishlistController.java
@@ -32,4 +32,13 @@ public class CustomerWishlistController {
         UserVo userVo = provider.getUserVo(token);
         return ResponseEntity.ok(wishlistApplication.getWishlist(userVo.getId()));
     }
+
+    @PutMapping
+    private ResponseEntity<Wishlist> updateWishlist(
+            @RequestHeader(name = "X-AUTH-TOKEN") String token,
+            @RequestBody Wishlist wishlist) {
+        UserVo userVo = provider.getUserVo(token);
+        return ResponseEntity.ok(wishlistApplication
+                .updateWishlist(userVo.getId(), wishlist));
+    }
 }


### PR DESCRIPTION
close #
- 고객이 자신의 Wishlist(장바구니)를 수정할 수 있는 기능을 추가했습니다.
- 수정한 장바구니 정보는 저장되며, 저장 후 최신 상태의 장바구니 정보를 반환합니다.
- 장바구니 수정 시 기존의 장바구니 조회 로직을 재사용하여 엣지 케이스를 처리하고 코드 생산성을 높혔습니다.

## 🛰️ Issue Number
#31 

## 작업종류
- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용
1. 장바구니 수정 기능 구현
- WishlistApplication.updateWishlist() : 장바구니의 내용을 수정.
- 수정한 장바구니는 redis에 저장 후 getWishlist(customerId) 메서드를 호출하여 장바구니 최신화.
- 상품 삭제, 수량 변경 등의 엣지 케이스를 처리하기 위해 기존의 장바구니 조회 로직 재사용.

2. API 엔드포인트
- 엔드포인트: PUT /customer/wishlist
```
{
  "customerId": 100,
  "products": [
    {
      "id": 1,
      "name": "Example Product",
      "description": "This is an example product",
      "productItems": [
        {
          "id": 101,
          "name": "Example Item",
          "price": 20000,
          "count": 2
        }
      ]
    }
  ]
}
```


## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
