### PR TITLE
feat: 도커 파일로 도커 이미지 만들고 실행해보기

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/api-gateway-0.0.1-SNAPSHOT.jar api-gateway.jar
+ENTRYPOINT ["java", "-DSpring.profiles.active=prod", "-jar","api-gateway.jar"]

--- a/api-gateway/build.gradle
+++ b/api-gateway/build.gradle
@@ -67,6 +67,11 @@ dependencyManagement {
 	}
 }
 
+bootJar {
+	enabled = true
+	jar.enabled = false
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/api-gateway/src/main/resources/application-prod.yml
+++ b/api-gateway/src/main/resources/application-prod.yml
@@ -1,0 +1,31 @@
+server:
+  port: 9090
+  shutdown: graceful
+
+spring:
+  main:
+    web-application-type: reactive
+
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}
+
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          enabled: true # 디스커버리를 통해 동적으로 라우트 관리
+
+eureka:
+  instance:
+    prefer-ip-address: true
+  client:
+    register-with-eureka: true
+    fetch-registry: true
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/discovery-server/Dockerfile
+++ b/discovery-server/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/discovery-server-0.0.1-SNAPSHOT.jar discovery-server.jar
+ENTRYPOINT ["java", "-DSpring.profiles.active=prod", "-jar","discovery-server.jar"]

--- a/discovery-server/build.gradle
+++ b/discovery-server/build.gradle
@@ -34,6 +34,11 @@ dependencyManagement {
 	}
 }
 
+bootJar {
+	enabled = true
+	jar.enabled = false
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
 }

--- a/discovery-server/src/main/resources/application-prod.yml
+++ b/discovery-server/src/main/resources/application-prod.yml
@@ -1,0 +1,26 @@
+server:
+  port: 8761
+  shutdown: graceful
+
+spring:
+  application:
+    name: discovery-server
+
+eureka:
+  instance:
+    hostname: localhost
+
+  client:
+    register-with-eureka: false
+    fetch-registry: false
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/
+
+  server:
+    wait-time-in-ms-when-sync-empty: 5
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"

--- a/order-api/Dockerfile
+++ b/order-api/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/order-api-0.0.1-SNAPSHOT.jar order-api.jar
+ENTRYPOINT ["java", "-DSpring.profiles.active=prod", "-jar","order-api.jar"]

--- a/order-api/build.gradle
+++ b/order-api/build.gradle
@@ -95,6 +95,11 @@ dependencyManagement {
     }
 }
 
+bootJar {
+    enabled = true
+    jar.enabled = false
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/order-api/src/main/resources/application-prod.yml
+++ b/order-api/src/main/resources/application-prod.yml
@@ -1,0 +1,41 @@
+server:
+  port: 8082
+  shutdown: graceful
+
+spring:
+  mvc:
+    path match:
+      matching-strategy: ant_path_matcher
+
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
+      autoconfiguration:
+        jackson:
+          enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    database: mysql
+
+  datasource:
+    url: jdbc:mysql://localhost:3306/order?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${DB_PASSWORD}
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/

--- a/user-api/Dockerfile
+++ b/user-api/Dockerfile
@@ -1,0 +1,3 @@
+FROM openjdk:21-jdk-slim
+COPY build/libs/user-api-0.0.1-SNAPSHOT.jar user-api.jar
+ENTRYPOINT ["java", "-DSpring.profiles.active=prod", "-Dmailgun.key={MAILGUN_KEY}","-jar","user-api.jar"]

--- a/user-api/build.gradle
+++ b/user-api/build.gradle
@@ -80,6 +80,11 @@ dependencyManagement {
     }
 }
 
+bootJar {
+    enabled = true
+    jar.enabled = false
+}
+
 tasks.named('test') {
     useJUnitPlatform()
 }

--- a/user-api/src/main/resources/application-prod.yml
+++ b/user-api/src/main/resources/application-prod.yml
@@ -1,0 +1,36 @@
+server:
+  port: 8081
+  shutdown: graceful
+
+spring:
+  mvc:
+    path match:
+      matching-strategy: ant_path_matcher
+
+  cloud:
+    openfeign:
+      okhttp:
+        enabled: true
+      autoconfiguration:
+        jackson:
+          enabled: true
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    database: mysql
+
+  datasource:
+    url: jdbc:mysql://chanhee-mysql.cxy4syck6vzh.ap-northeast-2.rds.amazonaws.com:3306/user?useSSL=false&useUnicode=true&allowPublicKeyRetrieval=true
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: root
+    password: ${DB_PASSWORD}
+
+  jwt:
+    secret-key: ${JWT_SECRET_KEY}
+
+eureka:
+  client:
+    serviceUrl:
+      defaultZone: http://localhost:8761/eureka/


### PR DESCRIPTION
close #
- 도커 파일을 사용한 서비스 컨테이너화 및 프로덕션 초기 설정을 추가했습니다.
- 각 서비스에 대해 Dockerfile을 작성하여 도커 컨테이너로 배포할 수 있도록 구성했습니다.
- 프로덕션 환경에서 사용할 application-prod.yml 설정 파일을 추가했습니다.
- Gradle 설정을 수정하여, Spring Boot의 bootJar 기능을 활성화하고, 기존 JAR 빌드를 비활성화했습니다.

## 🛰️ Issue Number
#47 
## 작업종류
- [ ] test 코드 작성
- [x] feature 병합
- [ ] 버그 수정
- [ ] 코드 개선
- [ ] 기타(아래에 자세한 내용 기입해주세요)

## 작업 세부 내용
1. Dockerfile 작성
- openjdk:21-jdk-slim 이미지를 기반으로 도커 컨테이너 생성.
- 빌드된 *.jar 파일을 컨테이너에 복사하고, prod 프로파일로 실행하도록 설정.
- Mailgun API 키를 환경 변수로 받아서 설정하고, prod 프로파일로 실행.

2. 프로덕션 환경 설정 (application-prod.yml)
- 각 서비스별로 프로덕션 환경에서 사용될 설정 파일을 추가했습니다:
    - API Gateway (api-gateway): 포트를 9090으로 설정하고, Eureka 클라이언트 설정 및 Spring Cloud Gateway 설정.
    - Discovery Server (discovery-server): 포트를 8761로 설정하고, Eureka 서버 설정.
    - Order API (order-api): 포트를 8082로 설정하고, 데이터베이스(MySQL)와 Redis 연결 설정.
    - User API (user-api): 포트를 8081로 설정하고, MySQL 데이터베이스 연결 및 JWT 설정.
3. Gradle 설정 변경
- bootJar 기능을 활성화하여, Spring Boot 애플리케이션을 실행할 JAR 파일 생성.
- 기존의 JAR 빌드 기능은 비활성화. (plain.jar 파일 생성 방지)


## 📚 Reference

## ✅ Check List
- [x] 커밋 컨벤션을 맞췄나요?
- [x] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
